### PR TITLE
No longer using request as iterator

### DIFF
--- a/pyramid_cas/services.py
+++ b/pyramid_cas/services.py
@@ -16,7 +16,7 @@ class CASProvider(object):
         """
         Returns current application's url
         """
-        if 'HTTP_X_FORWARDED_HOST' in request:
+        if 'HTTP_X_FORWARDED_HOST' in request.headers:
             # TODO get the http from the request
             applicationUrl = 'http://' +  request['HTTP_X_FORWARDED_HOST']
         else:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
     ]
 
 setup(name='pyramid_cas',
-      version='0.1 alpha',
+      version='0.2 alpha',
       description='pyramid_cas',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[


### PR DESCRIPTION
The api "header in request" doesn't work with recent pyramid versions. Corrected it.
